### PR TITLE
Fix insertAt in rga arrays with deleted records

### DIFF
--- a/src/rga.js
+++ b/src/rga.js
@@ -142,12 +142,18 @@ function insertAllAt (state, pos, values) {
   const [added, removed, edges] = state
   let i = 0
   let left = null
+  console.log('Added', added)
+  console.log('Removed', removed)
+  console.log('Edges', edges)
   while (i < pos) {
     if (removed.has(left)) {
       left = edges.get(left)
       continue
     }
     if (edges.has(left)) {
+      left = edges.get(left)
+    }
+    while (removed.has(left)) {
       left = edges.get(left)
     }
     i++

--- a/src/rga.js
+++ b/src/rga.js
@@ -142,9 +142,6 @@ function insertAllAt (state, pos, values) {
   const [added, removed, edges] = state
   let i = 0
   let left = null
-  console.log('Added', added)
-  console.log('Removed', removed)
-  console.log('Edges', edges)
   while (i < pos) {
     if (removed.has(left)) {
       left = edges.get(left)

--- a/test/rga.spec.js
+++ b/test/rga.spec.js
@@ -39,6 +39,15 @@ describe('rga', () => {
     it('and the value is inserted', () => {
       expect(rga.value()).to.deep.equal(['a', 'b'])
     })
+
+    it('can insert at correct spot after deleted sequence', () => {
+      rga.push('c')
+      rga.push('d')
+      rga.removeAt(1)
+      rga.removeAt(1)
+      rga.insertAt(2, 'e')
+      expect(rga.value()).to.deep.equal(['a', 'd', 'e'])
+    })
   })
 
   describe('together', () => {


### PR DESCRIPTION
insertAt would place the inserted records too early in the array
if some records had already been deleted at the same location.