### PR TITLE
Fix infinite loop in RGA push() when last edge points to null

### DIFF
--- a/src/rga.js
+++ b/src/rga.js
@@ -48,7 +48,7 @@ module.exports = (id) => ({
     push (state, value) {
       const [added, removed, edges] = state
       let last = null
-      while (edges.has(last) && (edges.get(last) !== undefined)) {
+      while (edges.has(last) && edges.get(last)) {
         last = edges.get(last)
       }
 


### PR DESCRIPTION
The problem is that msgpack-lite encodes `{ "id": undefined }` as `{ "id": null }`. See https://github.com/kawanet/msgpack-lite/issues/71

After adding a value to the RGA, the edge Map looks something like:
```
{
  null => "cjmi30qvl00013h5ph5d0p9a6"
  "cjmi30qvl00013h5ph5d0p9a6" => undefined
}
```
But after encoding it and then decoding it, it becomes:
```
{
  null => "cjmi30qvl00013h5ph5d0p9a6"
  "cjmi30qvl00013h5ph5d0p9a6" => null
}
```

So when we call `RGA push()`, the following lines in the `push()` method loop forever (because last is `null` instead of `undefined`:
```
      let last = null
      while (edges.has(last) && (edges.get(last) !== undefined)) {
        last = edges.get(last)
      }
```
