### PR TITLE
embed ormap failing test

### DIFF
--- a/test/ormap.spec.js
+++ b/test/ormap.spec.js
@@ -56,6 +56,16 @@ describe('ormap', () => {
     it('can get value', () => {
       expect(ormap.value()).to.deep.equal({b: new Set(['B'])})
     })
+
+    it('can embed ormap', () => {
+      const rreplica = ORMap('id1')
+      rreplica.applySub('om', 'ormap', 'applySub', 'a', 'mvreg', 'write', 'A1')
+      expect(rreplica.value().om.a).to.deep.equal(new Set(['A1']))
+      rreplica.applySub('om', 'ormap', 'remove', 'a')
+      expect(rreplica.value()).to.deep.equal({om: {}})
+      rreplica.remove('om')
+      expect(rreplica.value()).to.deep.equal({})
+    })
   })
 
   describe('together', () => {

--- a/test/ormap.spec.js
+++ b/test/ormap.spec.js
@@ -62,8 +62,6 @@ describe('ormap', () => {
       rreplica.applySub('om', 'ormap', 'applySub', 'a', 'mvreg', 'write', 'A1')
       expect(rreplica.value().om.a).to.deep.equal(new Set(['A1']))
       rreplica.applySub('om', 'ormap', 'remove', 'a')
-      expect(rreplica.value()).to.deep.equal({om: {}})
-      rreplica.remove('om')
       expect(rreplica.value()).to.deep.equal({})
     })
   })

--- a/test/ormap.spec.js
+++ b/test/ormap.spec.js
@@ -59,15 +59,15 @@ describe('ormap', () => {
 
     it('can embed ormap', () => {
       const rreplica = ORMap('id1')
-      rreplica.applySub('om', 'ormap', 'applySub', 'a', 'lwwreg', 'write', 1 ,'A1')
-      rreplica.applySub('om', 'ormap', 'applySub', 'b', 'lwwreg', 'write', 2 ,'A1')
-      rreplica.applySub('om2', 'ormap', 'applySub', 'a2', 'lwwreg', 'write', 2 ,'A2')
+      rreplica.applySub('om', 'ormap', 'applySub', 'a', 'lwwreg', 'write', 1, 'A1')
+      rreplica.applySub('om', 'ormap', 'applySub', 'b', 'lwwreg', 'write', 2, 'A1')
+      rreplica.applySub('om2', 'ormap', 'applySub', 'a2', 'lwwreg', 'write', 2, 'A2')
       expect(rreplica.value().om.a).to.deep.equal('A1')
       expect(rreplica.value().om.b).to.deep.equal('A1')
       expect(rreplica.value().om2.a2).to.deep.equal('A2')
       rreplica.applySub('om', 'ormap', 'remove', 'a')
-      rreplica.remove('om2');
-      expect(rreplica.value()).to.deep.equal({om:{b: 'A1'}})
+      rreplica.remove('om2')
+      expect(rreplica.value()).to.deep.equal({om: {b: 'A1'}})
     })
   })
 

--- a/test/ormap.spec.js
+++ b/test/ormap.spec.js
@@ -59,10 +59,15 @@ describe('ormap', () => {
 
     it('can embed ormap', () => {
       const rreplica = ORMap('id1')
-      rreplica.applySub('om', 'ormap', 'applySub', 'a', 'mvreg', 'write', 'A1')
-      expect(rreplica.value().om.a).to.deep.equal(new Set(['A1']))
+      rreplica.applySub('om', 'ormap', 'applySub', 'a', 'lwwreg', 'write', 1 ,'A1')
+      rreplica.applySub('om', 'ormap', 'applySub', 'b', 'lwwreg', 'write', 2 ,'A1')
+      rreplica.applySub('om2', 'ormap', 'applySub', 'a2', 'lwwreg', 'write', 2 ,'A2')
+      expect(rreplica.value().om.a).to.deep.equal('A1')
+      expect(rreplica.value().om.b).to.deep.equal('A1')
+      expect(rreplica.value().om2.a2).to.deep.equal('A2')
       rreplica.applySub('om', 'ormap', 'remove', 'a')
-      expect(rreplica.value()).to.deep.equal({})
+      rreplica.remove('om2');
+      expect(rreplica.value()).to.deep.equal({om:{b: 'A1'}})
     })
   })
 


### PR DESCRIPTION
Not sure if embedding `ormap` inside an `ormap` is supported. but adding seems to work fine ... removing fails.
this PR adds failing tests