### PR TITLE
Deserialize values when deserializing ORMap

### DIFF
--- a/src/dot-map.js
+++ b/src/dot-map.js
@@ -99,7 +99,13 @@ function dotMapFromRaw (base) {
     }
     cc.dc = dc
   }
-  const dotMap = new DotMap(cc, base.state)
+  const stateFromRaw = new Map()
+  for (const key of base.state.keys()) {
+    const value = base.state.get(key)
+    const type = CRDT.type(value.type)
+    stateFromRaw.set(key, type.join(value, type.initial()))
+  }
+  const dotMap = new DotMap(cc, stateFromRaw)
   dotMap.type = base.type
   return dotMap
 }

--- a/src/ormap.js
+++ b/src/ormap.js
@@ -45,6 +45,7 @@ module.exports = {
         throw new Error('unknown type name')
       }
       const newSubState = type.initial()
+      newSubState.type = dotStore.type
 
       return new DotMap(newCC, new Map([[key, newSubState]]))
     }

--- a/test/ormap.spec.js
+++ b/test/ormap.spec.js
@@ -7,6 +7,7 @@ const expect = chai.expect
 chai.use(dirtyChai)
 
 const CRDT = require('../')
+const DotSet = require('../src/dot-set')
 const transmit = require('./transmit')
 
 describe('ormap', () => {
@@ -114,6 +115,7 @@ describe('ormap', () => {
       replica2.apply(transmit(delta1))
       expect(replica2.value().b).to.deep.equal(new Set(['BB']))
       expect(replica1.value().b).to.deep.equal(new Set(['BB']))
+      expect(replica1.state().state.get('b')).instanceof(DotSet)
     })
   })
 })


### PR DESCRIPTION
In peer-star-app, our MVReg values weren't getting stored as DotSet
objects in the state.