### PR TITLE
Keep removals in ormap state

### DIFF
--- a/src/dot-map.js
+++ b/src/dot-map.js
@@ -69,10 +69,8 @@ class DotMap {
 
       newSub.type = sub1.type || sub2.type
 
-      if (!(newSub.isBottom && newSub.isBottom())) {
-        newSub.cc = null
-        newMap.set(key, newSub)
-      }
+      newSub.cc = null
+      newMap.set(key, newSub)
     }
 
     return result

--- a/src/ormap.js
+++ b/src/ormap.js
@@ -10,6 +10,7 @@ module.exports = {
   value (s) {
     const result = {}
     for (const [key, subState] of s.state) {
+      if (subState.isBottom && subState.isBottom()) continue
       const typeName = subState.type
       const type = CRDT.type(typeName)
       result[key] = type.value(subState)

--- a/test/ormap.spec.js
+++ b/test/ormap.spec.js
@@ -117,5 +117,12 @@ describe('ormap', () => {
       expect(replica1.value().b).to.deep.equal(new Set(['BB']))
       expect(replica1.state().state.get('b')).instanceof(DotSet)
     })
+
+    it('removals are stored in state', () => {
+      replica1.remove('b')
+      expect(replica1.value().b).to.not.exist()
+      replica2.apply(replica1.state())
+      expect(replica2.value().b).to.not.exist()
+    })
   })
 })


### PR DESCRIPTION
Removals were working when applying a delta, but they weren't being
retained in the state. So applying a state wouldn't remove entries
from the ormap.