### PR TITLE
Feature: support incremental view value computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,20 @@ CRDT.define('zero', Zero)
 const replica = CRDT('zero')('node id')
 ```
 
+### Support for incremental value computation
+
+It's possible to allow types to have incremental value computation. If a type supports that, the value is incrementally computed on each delta that is applied.
+
+To add support for incremental value computation to a CRDT, the type definition should support the following function:
+
+```js
+Type.incrementalValue = function (beforeState, newState, delta, cache = { value: <some initial value>, ... }) {
+  // ...
+}
+```
+
+As an example you can get inspiration from [the RGA implementation](src/rga.js).
+
 ## Types
 
 

--- a/src/ormap.js
+++ b/src/ormap.js
@@ -1,3 +1,4 @@
+/* eslint no-continue: "off" */
 'use strict'
 
 const DotMap = require('./dot-map')

--- a/src/rga.js
+++ b/src/rga.js
@@ -64,7 +64,7 @@ module.exports = {
           // not removed
           pos += 1
           let beforeRight = beforeEdges.get(left)
-          while (beforeRight && (beforeRight !== right)) {
+          while (beforeRight && (beforeRight > right)) {
             pos += 1
             beforeRight = beforeEdges.get(beforeRight)
           }

--- a/src/type.js
+++ b/src/type.js
@@ -7,7 +7,7 @@ module.exports = (Type) => {
     let state = Type.initial()
     const ret = new EventEmitter()
     const emitter = new ChangeEmitter(ret)
-    let valueCache = undefined
+    let valueCache
 
     Object.keys(Type.mutators || {}).forEach((mutatorName) => {
       const mutator = Type.mutators[mutatorName]

--- a/test/rga.spec.js
+++ b/test/rga.spec.js
@@ -71,14 +71,18 @@ describe('rga', () => {
     it('values can be written concurrently', () => {
       deltas[0].push(replica1.push('a'))
       deltas[0].push(replica1.push('b'))
+      expect(replica1.value()).to.deep.equal(['a', 'b'])
       deltas[1].push(replica2.push('c'))
       deltas[1].push(replica2.push('d'))
+      expect(replica2.value()).to.deep.equal(['c', 'd'])
     })
 
     it('waits a small bit', (done) => setTimeout(done, SMALL_BIT))
 
     it('the first converges', () => {
-      deltas[1].forEach((delta) => replica1.apply(transmit(delta)))
+      replica1.apply(transmit(deltas[1][0]))
+      expect(replica1.value()).to.deep.equal(['c', 'a', 'b'])
+      replica1.apply(transmit(deltas[1][1]))
       expect(replica1.value()).to.deep.equal(['c', 'd', 'a', 'b'])
     })
 
@@ -105,11 +109,13 @@ describe('rga', () => {
     it('values can be deleted concurrently', () => {
       deltas = [[], []]
       deltas[0].push(replica1.removeAt(1))
+      expect(replica1.value()).to.deep.equal(['c', 'a', 'b'])
       deltas[1].push(replica2.removeAt(2))
+      expect(replica2.value()).to.deep.equal(['c', 'd', 'b'])
     })
 
     it('the first converges', () => {
-      deltas[1].forEach((delta) => replica1.apply(transmit(delta)))
+      replica1.apply(transmit(deltas[1][0]))
       expect(replica1.value()).to.deep.equal(['c', 'b'])
     })
 


### PR DESCRIPTION
Currently, the view value (Type.value(state)) is re-computed every time, and this has at least a O(n) complexity.
An application typically listens to state changed events and then calls .value(state), which is expensive to do every time there is a mutation.

Instead of computing the state every time .value() is called, this PR allows to keep the value around and, on each delta applied, change the value accordingly.

So far, only the RGA type supports this.