### PR TITLE
Throw errors when applying deltas that depend on missing state

### DIFF
--- a/src/rga.js
+++ b/src/rga.js
@@ -120,7 +120,7 @@ module.exports = {
     },
 
     push (id, state, value) {
-      const [added, removed, edges] = state
+      const [, removed, edges] = state
       let last = null
       while (edges.has(last) && edges.get(last)) {
         last = edges.get(last)
@@ -129,9 +129,6 @@ module.exports = {
       const elemId = createUniqueId(state, id)
 
       const newAdded = new Map([[elemId, value]])
-      if (added.has(last)) {
-        newAdded.set(last, added.get(last))
-      }
       const newRemoved = new Set([])
       if (removed.has(last)) {
         newRemoved.add(last)
@@ -148,7 +145,7 @@ module.exports = {
     insertAllAt,
 
     updateAt (id, state, pos, value) {
-      return join(removeAt(id, state, pos), insertAt(id, state, pos, value))
+      return join(insertAt(id, state, pos, value), removeAt(id, state, pos))
     }
   }
 }
@@ -176,6 +173,9 @@ function join (s1, s2) {
         // bypass this edge, already inserted
         edgesToAdd.delete(key)
       } else if (resultEdges.has(key)) {
+        if (!added.has(newValue)) {
+          throw new Error('delta depends on missing vertex')
+        }
         insertEdge(edge)
         edgesToAdd.delete(key)
       }
@@ -212,7 +212,7 @@ function insertAt (id, state, pos, value) {
 }
 
 function insertAllAt (id, state, pos, values) {
-  const [added, removed, edges] = state
+  const [, removed, edges] = state
   let i = 0
   let left = null
   while (i < pos && edges.has(left)) {
@@ -228,9 +228,6 @@ function insertAllAt (id, state, pos, values) {
   }
 
   const newAdded = new Map()
-  if (added.has(left)) {
-    newAdded.set(left, added.get(left))
-  }
   const newRemoved = new Set()
   if (removed.has(left)) {
     newRemoved.add(left)

--- a/test/rga.spec.js
+++ b/test/rga.spec.js
@@ -190,7 +190,7 @@ describe('rga', () => {
     })
   })
 
-  describe('three way', () => {
+  describe('missing state', () => {
     let RGA = CRDT('rga')
 
     let replica1, replica2, replica3
@@ -259,6 +259,14 @@ describe('rga', () => {
       const replica = RGA('id')
       expect(() => {
         replica.apply(delta4)
+      }).to.throw(/delta depends on missing vertex/)
+    })
+
+    it('states and deltas apply, push addRight first', () => {
+      const delta = replica1.addRight(null, 'Z')
+      const replica = RGA('id')
+      expect(() => {
+        replica.apply(delta)
       }).to.throw(/delta depends on missing vertex/)
     })
   })

--- a/test/rga.spec.js
+++ b/test/rga.spec.js
@@ -189,4 +189,59 @@ describe('rga', () => {
       expect(replica1.value()).to.deep.equal(['c', 'B', 'g', 'g.2', 'g.1', 'h', 'e', 'f', 'm', 'n', 'k', 'l'])
     })
   })
+
+  describe('three way', () => {
+    let RGA = CRDT('rga')
+
+    let replica1, replica2, replica3
+    let state1, state2, delta3
+    before(() => {
+      replica1 = RGA('id1')
+      replica1.push('a')
+      replica1.push('b')
+      replica1.push('c')
+      state1 = replica1.state()
+      replica2 = RGA('id2')
+      replica2.push('d')
+      replica2.push('e')
+      replica2.push('f')
+      state2 = replica2.state()
+      replica3 = RGA('id2')
+      replica3.apply(state1)
+      replica3.apply(state2)
+      delta3 = replica3.insertAt(3, 'X')
+    })
+
+    it('states and deltas apply in original order', () => {
+      const replica = RGA('id')
+      replica.apply(state1)
+      replica.apply(state2)
+      replica.apply(delta3)
+      expect(replica.value().join('')).to.equal('defXabc')
+    })
+
+    it('states and deltas apply in modified order', () => {
+      const replica = RGA('id')
+      replica.apply(state2)
+      replica.apply(state1)
+      replica.apply(delta3)
+      expect(replica.value().join('')).to.equal('defXabc')
+    })
+
+    it('states and deltas apply, delta early', () => {
+      const replica = RGA('id')
+      replica.apply(state2)
+      replica.apply(delta3)
+      replica.apply(state1)
+      expect(replica.value().join('')).to.equal('defXabc')
+    })
+
+    it('states and deltas apply, delta first', () => {
+      const replica = RGA('id')
+      replica.apply(delta3)
+      replica.apply(state2)
+      replica.apply(state1)
+      expect(replica.value().join('')).to.equal('defXabc')
+    })
+  })
 })


### PR DESCRIPTION
Introduces a new "delta depends on missing vertex" error.

Previously, applying deltas would succeed, but result in inconsistent
results when state was applied afterwards.

For the 'push' and 'insertAt' mutations, this removes the redundant
initial added vertex (but leaves the edge) ... and uses that as a
signal to check to ensure that the vertex exists when applying the
delta.

TODO: Other mutations: addRight, remove, removeAt