### PR TITLE
Encode ids in mvreg

### DIFF
--- a/src/mvreg.js
+++ b/src/mvreg.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const DotSet = require('./dot-set')
+const { encode } = require('delta-crdts-msgpack-codec')
 
 module.exports = {
   initial () { return new DotSet() },
@@ -14,9 +15,10 @@ module.exports = {
   },
   mutators: {
     write (id, s, value) {
+      const encodedId = encode(id).toString('base64')
       return s.join(
         s.removeAll(),
-        s.add(id, value))
+        s.add(encodedId, value))
     }
   }
 }

--- a/test/mvreg.spec.js
+++ b/test/mvreg.spec.js
@@ -79,5 +79,15 @@ describe('mvreg', () => {
     it('and the second also converges', () => {
       expect(Array.from(replica2.value()).sort()).to.deep.equal(['hello', 'world'])
     })
+
+    it('binary ids also converge', () => {
+      const replicaA = MVReg(Buffer.from('idA'))
+      const deltaA = replicaA.write('a')
+      const replicaB = MVReg(Buffer.from('idB'))
+      replicaB.apply(deltaA)
+      const deltaB = replicaB.write('b')
+      replicaA.apply(deltaB)
+      expect(Array.from(replicaA.value()).sort()).to.deep.equal(['b'])
+    })
   })
 })


### PR DESCRIPTION
Peer-base uses Buffers for ids, which were getting serialized in
strange ways so the mvreg CRDT wasn't converging when syncing.

See: https://github.com/peer-base/peer-base/issues/287

This fix encodes the ids to strings, using a similar method as what
is used in the rga type.