### PR TITLE
Workaround for s.add, s.removeValue function resolution

### DIFF
--- a/src/aworset.js
+++ b/src/aworset.js
@@ -8,9 +8,11 @@ module.exports = {
   value (s) { return new Set(s.ds.values()) },
   mutators: {
     add (id, s, value) {
+      s = s instanceof DotSet ? s : new DotSet(s.ds, s.cc)
       return s.join(s.removeValue(value), s.add(id, value))
     },
     remove (id, s, value) {
+      s = s instanceof DotSet ? s : new DotSet(s.ds, s.cc)
       return s.removeValue(value)
     }
   }


### PR DESCRIPTION
Hi @jimpick @pgte - first of all, thanks for the `peer-base` and `js-delta-crdts` codebases; these are great.  I've been enjoying building with them and learning about the technologies involved.

I'm writing a browser-based application and would like to use a set with `aworset` semantics; add-wins seems most appropriate.

To include the dependencies, the application uses `browserify@16.5.0` executed via `browserify --standalone peer-base node_modules/peer-base/src/index.js`.  The resulting output script is included via a `script` tag, exposing peer-base functionality at `window.peerBase` in the DOM.

The **first** time the page loads - in either Firefox or Chrome - it's possible to add and remove items to the set:

```
# Firefox 69.0.1

var v, app = window.peerBase('app');
app.start().then(async function() {
    v = await app.collaborate('collaboration-name-1d7fa8', 'aworset');
});
> Promise { <state>: "pending" }
> Swarm listening on ...
> No options.keys ...

v.shared.value()
> Set []

v.shared.add('test')
> Promise { <state>: "fulfilled", <value>: undefined }

v.shared.add('test2')
> Promise { <state>: "fulfilled", <value>: undefined }

v.shared.remove('test')
> Promise { <state>: "fulfilled", <value>: undefined }

v.shared.value()
> Set [ "test2" ]
```

However when the page is loaded a **second** time - despite the `v.shared.value` being reloaded correctly - it becomes impossible to perform set operations:

```
# Firefox 69.0.1

v.shared.value()
> Set [ "test2" ]

v.shared.add('test3')
> Promise { <state>: "rejected" }
> TypeError: v.removeValue is not a function

v.shared.remove('test2')
> Promise { <state>: "rejected" }
> TypeError: v.removeValue is not a function
```

After some runtime debugging I found that the object `s` at these two locations:

https://github.com/ipfs-shipyard/js-delta-crdts/blob/0eb76c511952883f816eed3995d2963a76483343/src/aworset.js#L10
https://github.com/ipfs-shipyard/js-delta-crdts/blob/0eb76c511952883f816eed3995d2963a76483343/src/aworset.js#L13

... is a raw JSON dictionary during the second page load, instead of an expected instance of  type `DotSet`.

This pull request has a workaround - it doesn't feel like it's the correct solution, but I'm opening it to support the description of the problem and highlight what's going wrong.  Glad for any pointers and to help resolve this correctly.