### PR TITLE
 Add object equality support for rwlwwset 

### DIFF
--- a/src/lexjoin.js
+++ b/src/lexjoin.js
@@ -6,11 +6,14 @@ module.exports = (l, r, join, greaterThan) => {
 
   if (!greaterThan) { greaterThan = defaultGreaterThan }
 
-  if (greaterThan(l[0], r[0])) { return l }
-  if (greaterThan(r[0], l[0])) { return r }
+  const [lh, ...lt] = l
+  const [rh, ...rt] = r
+
+  if (greaterThan(lh, rh)) { return l }
+  if (greaterThan(rh, lh)) { return r }
 
   // First is equal, so join second
-  return [l[0], join(l[1], r[1])]
+  return [lh, ...join(lt, rt)]
 }
 
 function defaultGreaterThan (a, b) {

--- a/src/rwlwwset.js
+++ b/src/rwlwwset.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const lexjoin = require('./lexjoin')
+const objectKey = require('./object-key')
 
 module.exports = {
   initial () { return new Map() },
@@ -22,7 +23,7 @@ module.exports = {
   },
   value (s) {
     const res = new Set()
-    for (let [value, [, b]] of s) {
+    for (let [, [, b, value]] of s) {
       if (!b) {
         res.add(value)
       }
@@ -37,7 +38,8 @@ module.exports = {
 
 function addRemove (s, ts, val, b) {
   const res = new Map()
-  res.set(val, [ts, b])
+  const key = objectKey(val)
+  res.set(key, [ts, b, val])
 
   return res
 }

--- a/test/rwlwwset.spec.js
+++ b/test/rwlwwset.spec.js
@@ -40,6 +40,18 @@ describe('rwlwwset', () => {
     it('is now empty', () => {
       expect(rwlwwset.value().size).to.equal(0)
     })
+
+    it('deduplicates object with id', () => {
+      rwlwwset.add(3, { value: 'AAA' })
+      rwlwwset.add(4, { value: 'AAA' })
+      expect(rwlwwset.value().size).to.equal(1)
+      expect(rwlwwset.value()).to.deep.equal(new Set([{ value: 'AAA' }]))
+    })
+
+    it('can remove', () => {
+      rwlwwset.remove(5, { value: 'AAA' })
+      expect(rwlwwset.value().size).to.equal(0)
+    })
   })
 
   describe('together', () => {


### PR DESCRIPTION
This change enables object equality checks for the `rwlwwset` type via the existing `objectKey` function.

Test coverage is added based on similar functionality from the `aworset` type.